### PR TITLE
Added standard IO file access implementation

### DIFF
--- a/exif/exiffileio_test.go
+++ b/exif/exiffileio_test.go
@@ -1,0 +1,79 @@
+package exif
+
+import (
+	"testing"
+)
+
+func TestReadingExifFile(t *testing.T) {
+	file, err := OpenExifFileIo("../test-data/scan/DSC_0352.jpg")
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer func() { file.Close() }()
+
+	ifds, err := ReadExifTags(file)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	if len(ifds) != 88 {
+		t.Fatalf("Failed to find all 88 tags, found: %d", len(ifds))
+	}
+
+	tagMap := TagsAsMap(ifds)
+
+	if tag, ok := tagMap[nikonIso]; ok {
+		if tag.Value.([]uint16)[1] != 400 {
+			t.Fatalf("Invalid Nikon-specific ISO expected:400, actual: %v", tag.Value)
+		}
+	} else {
+		t.Fatalf("Failed to find nikon-specific ISO tag")
+	}
+
+	if tag, ok := tagMap[focalLength35]; ok {
+		if tag.Value.([]uint16)[0] != 27 {
+			t.Fatalf("Invalid 35mm focal length. Expected:27, actual: %v", tag.Value)
+		}
+	} else {
+		t.Fatalf("Failed to find 35mm focal length tag")
+	}
+}
+
+func TestReadingFileWithoutExif(t *testing.T) {
+	file, err := OpenExifFileIo("../test-data/fail/stack.jpg")
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer func() { file.Close() }()
+
+	ifds, err := ReadExifTags(file)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	if len(ifds) != 0 {
+		t.Fatalf("Should have found no tags")
+	}
+}
+
+func TestReadingNonExistingFile(t *testing.T) {
+	file, err := OpenExifFileIo("../test-data/fail/no-file.jpg")
+	if err == nil {
+		t.Fatalf("Should have failed to open file")
+		return
+	}
+	if file != nil {
+		file.Close()
+	}
+}
+
+func TestReadingEmptyFile(t *testing.T) {
+	file, err := OpenExifFileIo("../test-data/fail/empty.jpg")
+	if err == nil {
+		t.Fatalf("Should have failed to open file")
+		return
+	}
+	if file != nil {
+		t.Fatalf("Should have not returned the file")
+		file.Close()
+	}
+
+}

--- a/exif/exiffilemmap_test.go
+++ b/exif/exiffilemmap_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-func TestReadingExifFile(t *testing.T) {
-	file, err := OpenExifFile("../test-data/scan/DSC_0352.jpg")
+func TestReadingExifFileMMap(t *testing.T) {
+	file, err := OpenExifFileMMap("../test-data/scan/DSC_0352.jpg")
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
 	}
@@ -38,8 +38,8 @@ func TestReadingExifFile(t *testing.T) {
 	}
 }
 
-func TestReadingFileWithoutExif(t *testing.T) {
-	file, err := OpenExifFile("../test-data/fail/stack.jpg")
+func TestReadingFileWithoutExifMMap(t *testing.T) {
+	file, err := OpenExifFileMMap("../test-data/fail/stack.jpg")
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
 	}
@@ -54,17 +54,19 @@ func TestReadingFileWithoutExif(t *testing.T) {
 	}
 }
 
-func TestReadingNonExistingFile(t *testing.T) {
-	file, err := OpenExifFile("../test-data/fail/no-file.jpg")
+func TestReadingNonExistingFileMMap(t *testing.T) {
+	file, err := OpenExifFileMMap("../test-data/fail/no-file.jpg")
 	if err == nil {
 		t.Fatalf("Should have failed to open file")
 		return
 	}
-	file.Close()
+	if file != nil {
+		file.Close()
+	}
 }
 
-func TestReadingEmptyFile(t *testing.T) {
-	file, err := OpenExifFile("../test-data/fail/empty.jpg")
+func TestReadingEmptyFileMMap(t *testing.T) {
+	file, err := OpenExifFileMMap("../test-data/fail/empty.jpg")
 	if err == nil {
 		t.Fatalf("Should have failed to open file")
 		return

--- a/exif/exiffsfile.go
+++ b/exif/exiffsfile.go
@@ -1,0 +1,127 @@
+package exif
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/uaraven/exif-stat/logger"
+)
+
+type imageFileFs struct {
+	Path             string
+	File             *os.File
+	Order            byte
+	TiffHeaderOffset int64
+}
+
+// OpenExifFileIo opens file on a file system for reading
+func OpenExifFileIo(filepath string) (file File, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error(fmt.Sprintf("Failed to open file %s, Error: %v", filepath, r))
+			file = nil
+			err = fmt.Errorf("Failed to open file %s, Error: %v", filepath, r)
+		}
+	}()
+	f, err := os.Open(filepath)
+	defer func() {
+		if err != nil && f != nil {
+			f.Close()
+		}
+	}()
+	if err != nil {
+		return nil, err
+	}
+	file = &imageFileFs{
+		Path:  filepath,
+		File:  f,
+		Order: BigEndian,
+	}
+	word, err := file.readUint16()
+	if word != 0xFFD8 {
+		return nil, fmt.Errorf("Not a JPEG file? %s", filepath)
+	}
+
+	return file, nil
+}
+
+func (file imageFileFs) readUint16() (uint16, error) {
+	var word uint16
+	err := binary.Read(file.File, file.getByteOrder(), &word)
+	if err != nil {
+		return 0, err
+	}
+	return word, nil
+}
+
+func (file imageFileFs) readUint32() (uint32, error) {
+	var word uint32
+	err := binary.Read(file.File, file.getByteOrder(), &word)
+	if err != nil {
+		return 0, err
+	}
+	return word, nil
+}
+
+func (file imageFileFs) readBytes(size uint16) ([]byte, error) {
+	buf := make([]byte, size)
+	_, err := file.File.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func (file imageFileFs) currentPosition() (int64, error) {
+	return file.File.Seek(0, os.SEEK_CUR)
+}
+
+func (file imageFileFs) seek(pos int64) (int64, error) {
+	return file.File.Seek(pos, os.SEEK_SET)
+}
+
+func (file imageFileFs) seekRelative(pos int64) (int64, error) {
+	return file.File.Seek(pos, os.SEEK_CUR)
+}
+
+func (file imageFileFs) Read(out interface{}) error {
+	return binary.Read(file.File, file.getByteOrder(), out)
+}
+
+// Close closes the underlying file
+func (file imageFileFs) Close() {
+	file.File.Close()
+}
+
+func (file imageFileFs) GetFile() *os.File {
+	return file.File
+}
+
+func (file imageFileFs) getByteOrder() binary.ByteOrder {
+	if file.Order == BigEndian {
+		return binary.BigEndian
+	}
+	return binary.LittleEndian
+
+}
+
+func (file *imageFileFs) SetOrder(newOrder byte) {
+	file.Order = newOrder
+}
+
+func (file imageFileFs) GetOrder() byte {
+	return file.Order
+}
+
+func (file imageFileFs) GetTiffHeaderOffset() int64 {
+	return file.TiffHeaderOffset
+}
+
+func (file imageFileFs) GetPath() string {
+	return file.Path
+}
+
+func (file *imageFileFs) SetTiffHeaderOffset(newOffset int64) {
+	file.TiffHeaderOffset = newOffset
+}

--- a/exif/exifmmapfile.go
+++ b/exif/exifmmapfile.go
@@ -1,0 +1,140 @@
+package exif
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/edsrzf/mmap-go"
+	"github.com/uaraven/exif-stat/logger"
+)
+
+type imageFileMmap struct {
+	Path             string
+	File             *os.File
+	Data             mmap.MMap
+	Order            byte
+	Reader           *bytes.Reader
+	TiffHeaderOffset int64
+}
+
+// OpenExifFileMMap opens file for reading by mmapping it
+func OpenExifFileMMap(filepath string) (file File, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error(fmt.Sprintf("Failed to open file %s, Error: %v", filepath, r))
+			file = nil
+			err = fmt.Errorf("Failed to open file %s, Error: %v", filepath, r)
+		}
+	}()
+	f, err := os.Open(filepath)
+	defer func() {
+		if err != nil && f != nil {
+			f.Close()
+		}
+	}()
+	if err != nil {
+		return nil, err
+	}
+	data, err := mmap.Map(f, mmap.RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	reader := bytes.NewReader(data)
+	file = &imageFileMmap{
+		Path:   filepath,
+		File:   f,
+		Data:   data,
+		Reader: reader,
+		Order:  BigEndian,
+	}
+	word, err := file.readUint16()
+	if word != 0xFFD8 {
+		return nil, fmt.Errorf("Not a JPEG file? %s", filepath)
+	}
+
+	return file, nil
+}
+
+func (file imageFileMmap) readUint16() (uint16, error) {
+	var word uint16
+	err := binary.Read(file.Reader, file.getByteOrder(), &word)
+	if err != nil {
+		return 0, err
+	}
+	return word, nil
+}
+
+func (file imageFileMmap) readUint32() (uint32, error) {
+	var word uint32
+	err := binary.Read(file.Reader, file.getByteOrder(), &word)
+	if err != nil {
+		return 0, err
+	}
+	return word, nil
+}
+
+func (file imageFileMmap) readBytes(size uint16) ([]byte, error) {
+	buf := make([]byte, size)
+	_, err := file.Reader.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func (file imageFileMmap) currentPosition() (int64, error) {
+	return file.Reader.Seek(0, io.SeekCurrent)
+}
+
+func (file imageFileMmap) seek(pos int64) (int64, error) {
+	return file.Reader.Seek(pos, io.SeekStart)
+}
+
+func (file imageFileMmap) seekRelative(pos int64) (int64, error) {
+	return file.Reader.Seek(pos, io.SeekCurrent)
+}
+
+func (file imageFileMmap) Read(out interface{}) error {
+	return binary.Read(file.Reader, file.getByteOrder(), out)
+}
+
+// Close closes the underlying file
+func (file imageFileMmap) Close() {
+	file.Data.Unmap()
+	file.File.Close()
+}
+
+func (file imageFileMmap) GetFile() *os.File {
+	return file.File
+}
+
+func (file imageFileMmap) getByteOrder() binary.ByteOrder {
+	if file.Order == BigEndian {
+		return binary.BigEndian
+	}
+	return binary.LittleEndian
+
+}
+
+func (file *imageFileMmap) SetOrder(newOrder byte) {
+	file.Order = newOrder
+}
+
+func (file imageFileMmap) GetOrder() byte {
+	return file.Order
+}
+
+func (file imageFileMmap) GetTiffHeaderOffset() int64 {
+	return file.TiffHeaderOffset
+}
+
+func (file imageFileMmap) GetPath() string {
+	return file.Path
+}
+
+func (file *imageFileMmap) SetTiffHeaderOffset(newOffset int64) {
+	file.TiffHeaderOffset = newOffset
+}

--- a/exif/exifparse.go
+++ b/exif/exifparse.go
@@ -81,7 +81,7 @@ var tagNames = map[string]string{
 	nikonIso:             "ISO",
 }
 
-type tagReader func(file *File, count uint32) (interface{}, []byte, error)
+type tagReader func(file File, count uint32) (interface{}, []byte, error)
 
 var (
 	dataFormatTypes = []tagReader{
@@ -99,7 +99,7 @@ var (
 		float64Reader}          // double float
 )
 
-func readRawData(file *File, count uint32, bytesInElement uint32) ([]byte, error) {
+func readRawData(file File, count uint32, bytesInElement uint32) ([]byte, error) {
 	size := count * bytesInElement
 	if size < 4 {
 		size = 4
@@ -116,7 +116,7 @@ func readRawData(file *File, count uint32, bytesInElement uint32) ([]byte, error
 		if err != nil {
 			return nil, err
 		}
-		_, err = file.seek(file.TiffHeaderOffset + int64(offset))
+		_, err = file.seek(file.GetTiffHeaderOffset() + int64(offset))
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +126,7 @@ func readRawData(file *File, count uint32, bytesInElement uint32) ([]byte, error
 	return rawData, err
 }
 
-func asciiStringReader(file *File, count uint32) (interface{}, []byte, error) {
+func asciiStringReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 1)
 	if err != nil {
 		return nil, nil, err
@@ -137,7 +137,7 @@ func asciiStringReader(file *File, count uint32) (interface{}, []byte, error) {
 	return strings.TrimSpace(string(rawData)), rawData, nil
 }
 
-func unsignedByteReader(file *File, count uint32) (interface{}, []byte, error) {
+func unsignedByteReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 1)
 	if err != nil {
 		return nil, nil, err
@@ -145,33 +145,33 @@ func unsignedByteReader(file *File, count uint32) (interface{}, []byte, error) {
 	return rawData, rawData, nil
 }
 
-func signedByteReader(file *File, count uint32) (interface{}, []byte, error) {
+func signedByteReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 1)
 	if err != nil {
 		return nil, nil, err
 	}
 	signedBytes := make([]int8, count)
-	err = binary.Read(bytes.NewReader(rawData), file.Order, &signedBytes)
+	err = binary.Read(bytes.NewReader(rawData), file.getByteOrder(), &signedBytes)
 	if err != nil {
 		return nil, nil, err
 	}
 	return signedBytes, rawData, nil
 }
 
-func unsignedShortReader(file *File, count uint32) (interface{}, []byte, error) {
+func unsignedShortReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 2)
 	if err != nil {
 		return nil, nil, err
 	}
 	shorts := make([]uint16, count)
-	err = binary.Read(bytes.NewReader(rawData), file.Order, &shorts)
+	err = binary.Read(bytes.NewReader(rawData), file.getByteOrder(), &shorts)
 	if err != nil {
 		return nil, nil, err
 	}
 	return shorts, rawData, nil
 }
 
-func undefinedReader(file *File, count uint32) (interface{}, []byte, error) {
+func undefinedReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 1)
 	if err != nil {
 		return nil, nil, err
@@ -179,52 +179,52 @@ func undefinedReader(file *File, count uint32) (interface{}, []byte, error) {
 	return rawData, rawData, nil
 }
 
-func signedShortReader(file *File, count uint32) (interface{}, []byte, error) {
+func signedShortReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 2)
 	if err != nil {
 		return nil, nil, err
 	}
 	shorts := make([]int16, count)
-	err = binary.Read(bytes.NewReader(rawData), file.Order, &shorts)
+	err = binary.Read(bytes.NewReader(rawData), file.getByteOrder(), &shorts)
 	if err != nil {
 		return nil, nil, err
 	}
 	return shorts, rawData, nil
 }
 
-func unsignedLongReader(file *File, count uint32) (interface{}, []byte, error) {
+func unsignedLongReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 4)
 	if err != nil {
 		return nil, nil, err
 	}
 	longs := make([]uint32, count)
-	err = binary.Read(bytes.NewReader(rawData), file.Order, &longs)
+	err = binary.Read(bytes.NewReader(rawData), file.getByteOrder(), &longs)
 	if err != nil {
 		return nil, nil, err
 	}
 	return longs, rawData, nil
 }
 
-func signedLongReader(file *File, count uint32) (interface{}, []byte, error) {
+func signedLongReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 4)
 	if err != nil {
 		return nil, nil, err
 	}
 	longs := make([]int32, count)
-	err = binary.Read(bytes.NewReader(rawData), file.Order, &longs)
+	err = binary.Read(bytes.NewReader(rawData), file.getByteOrder(), &longs)
 	if err != nil {
 		return nil, nil, err
 	}
 	return longs, rawData, nil
 }
 
-func unsignedRationalReader(file *File, count uint32) (interface{}, []byte, error) {
+func unsignedRationalReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 8)
 	if err != nil {
 		return nil, nil, err
 	}
 	longs := make([]uint32, count*2)
-	err = binary.Read(bytes.NewReader(rawData), file.Order, &longs)
+	err = binary.Read(bytes.NewReader(rawData), file.getByteOrder(), &longs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -235,13 +235,13 @@ func unsignedRationalReader(file *File, count uint32) (interface{}, []byte, erro
 	return rationals, rawData, nil
 }
 
-func signedRationalReader(file *File, count uint32) (interface{}, []byte, error) {
+func signedRationalReader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 8)
 	if err != nil {
 		return nil, nil, err
 	}
 	longs := make([]int32, count*2)
-	err = binary.Read(bytes.NewReader(rawData), file.Order, &longs)
+	err = binary.Read(bytes.NewReader(rawData), file.getByteOrder(), &longs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -252,33 +252,33 @@ func signedRationalReader(file *File, count uint32) (interface{}, []byte, error)
 	return rationals, rawData, nil
 }
 
-func float64Reader(file *File, count uint32) (interface{}, []byte, error) {
+func float64Reader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 8)
 	if err != nil {
 		return nil, nil, err
 	}
 	floats := make([]float64, count)
-	err = binary.Read(bytes.NewReader(rawData), file.Order, &floats)
+	err = binary.Read(bytes.NewReader(rawData), file.getByteOrder(), &floats)
 	if err != nil {
 		return nil, nil, err
 	}
 	return floats, rawData, nil
 }
 
-func float32Reader(file *File, count uint32) (interface{}, []byte, error) {
+func float32Reader(file File, count uint32) (interface{}, []byte, error) {
 	rawData, err := readRawData(file, count, 4)
 	if err != nil {
 		return nil, nil, err
 	}
 	floats := make([]float32, count)
-	err = binary.Read(bytes.NewReader(rawData), file.Order, &floats)
+	err = binary.Read(bytes.NewReader(rawData), file.getByteOrder(), &floats)
 	if err != nil {
 		return nil, nil, err
 	}
 	return floats, rawData, nil
 }
 
-func readMarker(file *File) (*marker, error) {
+func readMarker(file File) (*marker, error) {
 	markerID, err := file.readUint16()
 	if err != nil {
 		return nil, err
@@ -298,7 +298,7 @@ func readMarker(file *File) (*marker, error) {
 	}, nil
 }
 
-func readIfdEntry(file *File) (*ifdEntry, error) {
+func readIfdEntry(file File) (*ifdEntry, error) {
 	var tagNumber uint16
 	err := file.Read(&tagNumber)
 	if err != nil {
@@ -338,14 +338,14 @@ func readIfdEntry(file *File) (*ifdEntry, error) {
 	return &ifdEntry{ComponentCount: numComponents, TagID: tagNumber, DataType: dataFormat, Data: dataValue, Value: value, ValueBytes: rawData}, nil
 }
 
-func readIfd(file *File, offset int64, ifdIndex int) (*ifd, error) {
+func readIfd(file File, offset int64, ifdIndex int) (*ifd, error) {
 	if offset > 0 {
 		pos, err := file.currentPosition()
 		if err != nil {
 			return nil, err
 		}
 		defer func() { file.seek(pos) }()
-		_, err = file.seek(file.TiffHeaderOffset + offset)
+		_, err = file.seek(file.GetTiffHeaderOffset() + offset)
 		if err != nil {
 			return nil, err
 		}
@@ -378,7 +378,7 @@ func entryToTag(parents []uint16, entry ifdEntry) Tag {
 	}
 }
 
-func entriesToTags(parentIDs []uint16, file *File, entries []ifdEntry) (Tags, error) {
+func entriesToTags(parentIDs []uint16, file File, entries []ifdEntry) (Tags, error) {
 	tags := make([]Tag, 0)
 	for _, entry := range entries {
 		if entry.TagID == exifTagID {
@@ -417,7 +417,7 @@ func entriesToTags(parentIDs []uint16, file *File, entries []ifdEntry) (Tags, er
 	return tags, nil
 }
 
-func readExifHeader(file *File, marker *marker) error {
+func readExifHeader(file File, marker *marker) error {
 	// check headers
 	file.seek(marker.Offset)
 	// examine exif header
@@ -447,13 +447,13 @@ func readExifHeader(file *File, marker *marker) error {
 		return err
 	}
 
-	file.TiffHeaderOffset = tiffHeaderOffset
+	file.SetTiffHeaderOffset(tiffHeaderOffset)
 
 	// we're at IFD0 and can start reading IFDs
 	return nil
 }
 
-func readIfds(file *File) ([]ifd, error) {
+func readIfds(file File) ([]ifd, error) {
 	result := make([]ifd, 0)
 	index := 0
 	for {
@@ -469,7 +469,7 @@ func readIfds(file *File) ([]ifd, error) {
 		if offset == 0 {
 			return result, nil
 		}
-		_, err = file.seek(file.TiffHeaderOffset + int64(offset))
+		_, err = file.seek(file.GetTiffHeaderOffset() + int64(offset))
 		if err != nil { // most likely we're seeked past EOF
 			return result, nil
 		}
@@ -477,7 +477,7 @@ func readIfds(file *File) ([]ifd, error) {
 	}
 }
 
-func readTiffHeader(file *File) error {
+func readTiffHeader(file File) error {
 	// examine TIFF header
 
 	var wword uint32
@@ -486,9 +486,9 @@ func readTiffHeader(file *File) error {
 		return err
 	}
 	if wword == 0x49492A00 {
-		file.Order = binary.LittleEndian
+		file.SetOrder(LittleEndian)
 	} else if wword == 0x4d4d002A {
-		file.Order = binary.BigEndian
+		file.SetOrder(BigEndian)
 	} else {
 		return fmt.Errorf("Invalid byte order in TIFF header %x", wword)
 	}
@@ -504,7 +504,7 @@ func readTiffHeader(file *File) error {
 }
 
 // ReadExifTags parses file, extracts Ifds from it and parses ifds for all tags
-func ReadExifTags(file *File) (Tags, error) {
+func ReadExifTags(file File) (Tags, error) {
 	// find exif marker in the file
 	var marker *marker
 	var err error
@@ -523,7 +523,7 @@ func ReadExifTags(file *File) (Tags, error) {
 		}
 	}
 	if marker.Marker != exifDataMarker {
-		return nil, fmt.Errorf("Cannot find exif data in %s", file.Path)
+		return nil, fmt.Errorf("Cannot find exif data in %s", file.GetPath())
 	}
 	err = readExifHeader(file, marker)
 	if err != nil {

--- a/exifstat.go
+++ b/exifstat.go
@@ -16,6 +16,7 @@ var (
 		} `positional-args:"yes" positional-arg-name:"folder-path" description:"Path to folder with image files" required:"yes"`
 		OutputFile    string `short:"o" long:"output" description:"Name of the output CSV file" default:"exif-stats.csv"`
 		Verbose       bool   `short:"v" long:"verbose" description:"Output more informationm, including warnings"`
+		FastFile      bool   `long:"fast-io" description:"Use memory-mapped io. May be unstable with network paths"`
 		WriteFileName bool   `short:"f" long:"file-name" description:"Include file name in the output"`
 	}{}
 )
@@ -100,7 +101,7 @@ func main() {
 		total = 1 // to avoid div by zero later
 	}
 	for index, image := range images {
-		exif, err := ExtractExif(image)
+		exif, err := ExtractExif(image, options.FastFile)
 		if err != nil {
 			logger.Verbose(1, fmt.Sprintf("\nFailed to extract EXIF from '%s': %s", image, err))
 		} else {

--- a/jpegreader.go
+++ b/jpegreader.go
@@ -252,9 +252,14 @@ func parseExifFullTimestamp(timestamp string) (*time.Time, error) {
 }
 
 // ExtractExif parses image file with a given path and extracts exif information
-func ExtractExif(imageFilePath string) (*ExifInfo, error) {
-
-	file, err := exif.OpenExifFile(imageFilePath)
+func ExtractExif(imageFilePath string, mmap bool) (*ExifInfo, error) {
+	var file exif.File
+	var err error
+	if mmap {
+		file, err = exif.OpenExifFileMMap(imageFilePath)
+	} else {
+		file, err = exif.OpenExifFileIo(imageFilePath)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/jpegreader.go
+++ b/jpegreader.go
@@ -252,28 +252,35 @@ func parseExifFullTimestamp(timestamp string) (*time.Time, error) {
 }
 
 // ExtractExif parses image file with a given path and extracts exif information
-func ExtractExif(imageFilePath string, mmap bool) (*ExifInfo, error) {
-	var file exif.File
-	var err error
+func ExtractExif(imageFilePath string, mmap bool) (exifInfo *ExifInfo, err error) {
+	exifInfo = &ExifInfo{
+		FileName: imageFilePath,
+	}
+	defer func() {
+		state := recover()
+		if state != nil {
+			logger.Verbose(2, fmt.Sprintf("Faulted while reading %s: %v", imageFilePath, state))
+			exifInfo = nil
+			err = fmt.Errorf("Faulted while reading %s: %v", imageFilePath, state)
+		}
+	}()
+	var f exif.File
 	if mmap {
-		file, err = exif.OpenExifFileMMap(imageFilePath)
+		f, err = exif.OpenExifFileMMap(imageFilePath)
 	} else {
-		file, err = exif.OpenExifFileIo(imageFilePath)
+		f, err = exif.OpenExifFileIo(imageFilePath)
 	}
 	if err != nil {
 		return nil, err
 	}
-	defer func() { file.Close() }()
+	defer func() { f.Close() }()
 
-	tags, err := exif.ReadExifTags(file)
+	tags, err := exif.ReadExifTags(f)
 	if err != nil {
 		return nil, err
 	}
 
 	tagMap := exif.TagsAsMap(tags)
-	exifInfo := &ExifInfo{
-		FileName: imageFilePath,
-	}
 
 	for path, extractor := range extractors {
 		tag, ok := tagMap[path]

--- a/jpegreader_test.go
+++ b/jpegreader_test.go
@@ -39,7 +39,7 @@ func TestCameras(t *testing.T) {
 	}
 	for _, camera := range cameras {
 		filepath := "test-data/cameras/" + camera.Image
-		exifInfo, err := ExtractExif(filepath)
+		exifInfo, err := ExtractExif(filepath, false)
 		if err != nil {
 			t.Errorf("Failed to read exif from %s: %v", filepath, err)
 		}


### PR DESCRIPTION
This should work better than mmap on weird network paths.
With mmaps you get sigsegv when IO error occurs.

mmaps may still be used with `--fast-io` switch